### PR TITLE
feat: split tortie layer rolling into sub-element stages with quick preview

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/public/assets/styles/pages/adoption-generator.css
+++ b/frontend/public/assets/styles/pages/adoption-generator.css
@@ -677,3 +677,94 @@ body.overlay-open {
         flex: 1 1 150px;
     }
 }
+
+/* Cat Label Row */
+.adoption-generator .cat-label-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+}
+
+/* Quick Preview Button */
+.adoption-generator .cat-preview {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(15, 23, 42, 0.7);
+    color: rgba(226, 232, 240, 0.8);
+    font-size: 12px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    flex-shrink: 0;
+}
+
+.adoption-generator .cat-preview:hover {
+    background: rgba(59, 130, 246, 0.3);
+    border-color: rgba(59, 130, 246, 0.6);
+    transform: scale(1.1);
+}
+
+/* Quick Preview Popup */
+.quick-preview-popup {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1300;
+}
+
+.quick-preview-popup.open {
+    display: flex;
+}
+
+.quick-preview-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(2, 6, 23, 0.75);
+    backdrop-filter: blur(6px);
+}
+
+.quick-preview-content {
+    position: relative;
+    background: rgba(15, 23, 42, 0.95);
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    border-radius: 20px;
+    padding: 20px;
+    box-shadow: 0 32px 64px rgba(0, 0, 0, 0.5);
+    z-index: 1;
+}
+
+.quick-preview-canvas {
+    display: block;
+    image-rendering: pixelated;
+    border-radius: 12px;
+}
+
+.quick-preview-close {
+    position: absolute;
+    top: -12px;
+    right: -12px;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    border: 1px solid rgba(148, 163, 184, 0.4);
+    background: rgba(15, 23, 42, 0.95);
+    color: rgba(226, 232, 240, 0.9);
+    font-size: 16px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.quick-preview-close:hover {
+    background: rgba(248, 113, 113, 0.25);
+    color: #fca5a5;
+}


### PR DESCRIPTION
## Summary
- Split tortie layers into 3 separate stages (mask, pelt, colour) instead of rolling all at once
- Each sub-element stage triggers one cat elimination
- Show placeholder values (WHITE colour, default pattern) for unrevealed elements so cats stay rendered
- Add quick preview popup (700x700) with magnify button next to "Cat X" label
- Click outside or press Escape to close the preview popup
- Bump version to 0.2.0

## Test plan
- [ ] Navigate to /adoption-generator
- [ ] Set tortie count to 1 or more
- [ ] Generate adoption and verify:
  - [ ] Tortie mask rolls separately with elimination after
  - [ ] Tortie pelt rolls separately with elimination after  
  - [ ] Tortie colour rolls separately with elimination after
  - [ ] Unrevealed sub-elements show "—" placeholder in text
  - [ ] Cat stays rendered with WHITE placeholder colour until colour is revealed
- [ ] Click the 🔍 button next to any cat label
- [ ] Verify popup shows 700x700 preview
- [ ] Click outside popup to close
- [ ] Press Escape to close popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor keyboard event handling issues
- The core tortie splitting logic is well-implemented with proper state tracking and placeholder handling. The quick preview feature is cleanly implemented. However, the Escape key handling has two issues: duplicate event listeners could be registered if `createQuickPreviewPopup()` is called multiple times, and the two separate Escape handlers don't coordinate properly when both quick preview and detail overlay are open.
- frontend/lib/adoption/adoptionGenerator.js:217 and :1767 for keyboard event coordination

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| frontend/lib/adoption/adoptionGenerator.js | Split tortie layer rolling into 3 sub-stages (mask, pelt, colour) with placeholder values, and added quick preview popup with 700x700 canvas |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->