### PR TITLE
fix: remove paths filter to allow tag-triggered builds

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -6,9 +6,6 @@ on:
       - main
     tags:
       - 'v*'
-    paths:
-      - 'frontend/**'
-      - 'backend/renderer_service/**'
   workflow_dispatch:
     inputs:
       build_frontend:


### PR DESCRIPTION
## Summary
- Remove `paths` filter from build workflow trigger
- Fixes tag-triggered builds not running (v1.3.1, frontend-v1.4.0 didn't build)

The `paths` filter was blocking tag pushes since tags don't have file changes. Job-level conditions already handle path filtering for branch pushes.

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger build for v1.3.1 tag, or wait for next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no concerns
- The change is minimal, targeted, and fixes a clear bug in the CI/CD workflow. The logic is straightforward: trigger conditions at the job level already provide proper path filtering, making the top-level `paths` filter redundant and harmful to tag-triggered builds. This aligns with the project's Release Please workflow where tags trigger the Docker build step. No files were deleted, added incorrectly, or have security implications.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-images.yml | Removed `paths` filter from workflow trigger to allow tag-triggered builds. The `paths` filter was blocking automated releases from building Docker images. Job-level conditions properly handle path filtering for branch pushes while allowing tag pushes to trigger builds. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->