### PR TITLE
feat: add PostHog reverse proxy via Next.js rewrites

### DIFF
--- a/frontend/components/posthog-provider.tsx
+++ b/frontend/components/posthog-provider.tsx
@@ -4,7 +4,7 @@ import posthog from "posthog-js";
 import { ReactNode, useEffect } from "react";
 
 const KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY;
-const HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://eu.i.posthog.com";
+const HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "/bubu";
 
 function isLocalHost(hostname: string | undefined) {
   if (!hostname) return false;
@@ -36,7 +36,8 @@ export function PosthogProvider({ children }: { children: ReactNode }) {
     if (!(posthog as unknown as { __loaded?: boolean }).__loaded) {
       posthog.init(KEY, {
         api_host: HOST,
-        // 'history_change' auto-captures $pageview on SPA navigation AND $pageleave
+        ui_host: "https://eu.posthog.com",
+        // Auto-capture $pageview on SPA navigation; pageleave enabled separately below
         capture_pageview: "history_change",
         capture_pageleave: true,
         persistence: "localStorage",
@@ -49,5 +50,5 @@ export function PosthogProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  return <>{children}</>;
+  return children;
 }

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -66,6 +66,7 @@ if (process.env.NEXT_SHOW_CONFIG_LOGS === "1") {
 
 const nextConfig = {
   output: "standalone",
+  skipTrailingSlashRedirect: true,
   allowedDevOrigins,
   images: {
     remotePatterns,
@@ -75,6 +76,19 @@ const nextConfig = {
   },
   turbopack: {
     root: projectRoot,
+  },
+  async rewrites() {
+    // Proxy PostHog requests through /bubu to avoid ad-blockers
+    return [
+      {
+        source: "/bubu/static/:path*",
+        destination: "https://eu-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/bubu/:path*",
+        destination: "https://eu.i.posthog.com/:path*",
+      },
+    ];
   },
   async redirects() {
     return [


### PR DESCRIPTION
Route PostHog requests through /bubu path to bypass ad-blockers.
- Add rewrites in next.config.mjs for EU PostHog endpoints
- Enable skipTrailingSlashRedirect for PostHog API compatibility
- Update default api_host to /bubu and add ui_host

Powered by human calories and mass GPU cycles.
