### PR TITLE
fix: preserve OBS afterlife history

### DIFF
--- a/frontend/components/stream-control/OBSSpinClient.tsx
+++ b/frontend/components/stream-control/OBSSpinClient.tsx
@@ -3651,12 +3651,15 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
       // OBS: Use override params from the control page if available
       const override = overrideParamsRef.current;
       overrideParamsRef.current = null; // consume once
+      const overrideParams = override?.params;
+      const overrideSlots = override?.slots;
+      const usingOverrideParams = Boolean(overrideParams);
       // biome-ignore lint/suspicious/noExplicitAny: dynamic random generation result with varying shape
       let randomResult: any;
-      if (override?.params) {
+      if (overrideParams) {
         randomResult = {
-          params: override.params as Record<string, unknown>,
-          slotSelections: override.slots as typeof randomResult.slotSelections,
+          params: overrideParams as Record<string, unknown>,
+          slotSelections: overrideSlots as typeof randomResult.slotSelections,
         };
       } else {
         if (!generator.generateRandomCat) {
@@ -3708,11 +3711,18 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
 
       initMaxLayerRows();
 
-      const { darkForest: enableDarkForest, dead: enableDead } =
-        resolveAfterlife(afterlifeMode);
-      params.darkForest = enableDarkForest;
-      params.darkMode = enableDarkForest;
-      params.dead = enableDead;
+      if (usingOverrideParams) {
+        const enableDarkForest = Boolean(params.darkForest || params.darkMode);
+        params.darkForest = enableDarkForest;
+        params.darkMode = enableDarkForest;
+        params.dead = Boolean(params.dead);
+      } else {
+        const { darkForest: enableDarkForest, dead: enableDead } =
+          resolveAfterlife(afterlifeMode);
+        params.darkForest = enableDarkForest;
+        params.darkMode = enableDarkForest;
+        params.dead = enableDead;
+      }
 
       const countsResult: GenerationCounts = {
         accessories: accessorySlots.length,
@@ -3723,7 +3733,7 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
       setRollSummary(
         `Rolled → Accessories: ${countsResult.accessories} • Scars: ${countsResult.scars} • Tortie layers: ${countsResult.tortie}`,
       );
-      setHasTint(Boolean(enableDarkForest || enableDead));
+      setHasTint(Boolean(params.darkForest || params.dead));
       setSpriteGalleryOpen(false);
 
       const uniqueAccessories: string[] = Array.from(

--- a/frontend/components/stream-control/OBSSpinClient.tsx
+++ b/frontend/components/stream-control/OBSSpinClient.tsx
@@ -1155,27 +1155,51 @@ function getParameterValueForDisplay(
 
 function parseStreamWheelSpin(value: unknown): StreamWheelSpin | null {
   if (!value || typeof value !== "object") {
-    console.error("[OBSSpinClient] Invalid wheelSpin data — not an object", value);
+    console.error(
+      "[OBSSpinClient] Invalid wheelSpin data — not an object",
+      value,
+    );
     return null;
   }
   const spin = value as Partial<StreamWheelSpin>;
   if (
-    typeof spin.prizeName !== "string" ||
     typeof spin.prizeIndex !== "number" ||
-    typeof spin.color !== "string" ||
-    typeof spin.chance !== "number" ||
+    !Number.isInteger(spin.prizeIndex) ||
+    spin.prizeIndex < 0 ||
+    spin.prizeIndex >= CLASSIC_WHEEL_PRIZES.length ||
     typeof spin.forced !== "boolean"
   ) {
-    console.error("[OBSSpinClient] Invalid wheelSpin data — missing or wrong fields", value);
+    console.error(
+      "[OBSSpinClient] Invalid wheelSpin data — missing or wrong fields",
+      value,
+    );
     return null;
   }
+  const prize = CLASSIC_WHEEL_PRIZES[spin.prizeIndex];
+  if (
+    spin.prizeName !== prize.name ||
+    spin.color !== prize.color ||
+    spin.chance !== prize.chance
+  ) {
+    console.error(
+      "[OBSSpinClient] Invalid wheelSpin data - prize fields do not match index",
+      value,
+    );
+    return null;
+  }
+  const randomBucket =
+    typeof spin.randomBucket === "number" &&
+    Number.isFinite(spin.randomBucket) &&
+    spin.randomBucket >= 0 &&
+    spin.randomBucket < 100
+      ? spin.randomBucket
+      : undefined;
   return {
-    prizeName: spin.prizeName,
+    prizeName: prize.name,
     prizeIndex: spin.prizeIndex,
-    color: spin.color,
-    chance: spin.chance,
-    randomBucket:
-      typeof spin.randomBucket === "number" ? spin.randomBucket : undefined,
+    color: prize.color,
+    chance: prize.chance,
+    randomBucket,
     forced: spin.forced,
   };
 }
@@ -1183,20 +1207,16 @@ function parseStreamWheelSpin(value: unknown): StreamWheelSpin | null {
 function toClassicWheelSelection(
   wheelSpin: StreamWheelSpin,
 ): ClassicWheelSelection {
-  const fallbackPrize = {
-    name: wheelSpin.prizeName,
-    chance: wheelSpin.chance,
-    color: wheelSpin.color,
-  };
-  const prize = CLASSIC_WHEEL_PRIZES[wheelSpin.prizeIndex];
-  if (!prize) {
-    console.warn(
-      `[OBSSpinClient] Prize index ${wheelSpin.prizeIndex} out of range (max ${CLASSIC_WHEEL_PRIZES.length - 1}), using fallback`,
-    );
-  }
+  const index =
+    Number.isInteger(wheelSpin.prizeIndex) &&
+    wheelSpin.prizeIndex >= 0 &&
+    wheelSpin.prizeIndex < CLASSIC_WHEEL_PRIZES.length
+      ? wheelSpin.prizeIndex
+      : CLASSIC_WHEEL_PRIZES.length - 1;
+  const prize = CLASSIC_WHEEL_PRIZES[index];
   return {
-    prize: prize ?? fallbackPrize,
-    index: prize ? wheelSpin.prizeIndex : CLASSIC_WHEEL_PRIZES.length - 1,
+    prize,
+    index,
     random: wheelSpin.randomBucket,
   };
 }
@@ -2556,7 +2576,9 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
         if (generationIdRef.current !== token) return;
         await wheelRef.current.spinTo(wheelSelection);
       } else {
-        console.warn("[OBSSpinClient] Wheel ref not available after 1s polling — falling back to timed delay");
+        console.warn(
+          "[OBSSpinClient] Wheel ref not available after 1s polling — falling back to timed delay",
+        );
         await wait(WHEEL_SPIN_DURATION_MS);
       }
 
@@ -3386,6 +3408,22 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
       if (toastTimerRef.current) {
         window.clearTimeout(toastTimerRef.current);
         toastTimerRef.current = null;
+      }
+      if (countdownTimerRef.current) {
+        clearTimeout(countdownTimerRef.current);
+        countdownTimerRef.current = null;
+      }
+      if (previewIntervalRef.current) {
+        clearInterval(previewIntervalRef.current);
+        previewIntervalRef.current = null;
+      }
+      if (autoClearTimerRef.current) {
+        clearTimeout(autoClearTimerRef.current);
+        autoClearTimerRef.current = null;
+      }
+      if (fadeTimerRef.current) {
+        clearTimeout(fadeTimerRef.current);
+        fadeTimerRef.current = null;
       }
     };
   }, []);
@@ -4726,22 +4764,51 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
 
   /** Cancel running timers + reset roller/param state for phase transitions */
   const resetCommandState = useCallback(() => {
-    if (countdownTimerRef.current) clearTimeout(countdownTimerRef.current);
-    if (previewIntervalRef.current) clearInterval(previewIntervalRef.current);
-    if (autoClearTimerRef.current) clearTimeout(autoClearTimerRef.current);
+    if (countdownTimerRef.current) {
+      clearTimeout(countdownTimerRef.current);
+      countdownTimerRef.current = null;
+    }
+    if (previewIntervalRef.current) {
+      clearInterval(previewIntervalRef.current);
+      previewIntervalRef.current = null;
+    }
+    if (autoClearTimerRef.current) {
+      clearTimeout(autoClearTimerRef.current);
+      autoClearTimerRef.current = null;
+    }
+    if (fadeTimerRef.current) {
+      clearTimeout(fadeTimerRef.current);
+      fadeTimerRef.current = null;
+    }
     generationIdRef.current++;
     setParamRows([]);
     setRollerLabel(null);
     setRollerActiveValue(null);
+    setCountdownPreview(null);
+    setCountdownValue(0);
+    setSpinBoardVisible(false);
     setSpinDone(false);
     resetWheelOverlay();
   }, [resetWheelOverlay]);
 
   const handleWheelCommand = useCallback(
     async (wheelSpin: StreamWheelSpin, params?: unknown, slots?: unknown) => {
-      if (countdownTimerRef.current) clearTimeout(countdownTimerRef.current);
-      if (previewIntervalRef.current) clearInterval(previewIntervalRef.current);
-      if (autoClearTimerRef.current) clearTimeout(autoClearTimerRef.current);
+      if (countdownTimerRef.current) {
+        clearTimeout(countdownTimerRef.current);
+        countdownTimerRef.current = null;
+      }
+      if (previewIntervalRef.current) {
+        clearInterval(previewIntervalRef.current);
+        previewIntervalRef.current = null;
+      }
+      if (autoClearTimerRef.current) {
+        clearTimeout(autoClearTimerRef.current);
+        autoClearTimerRef.current = null;
+      }
+      if (fadeTimerRef.current) {
+        clearTimeout(fadeTimerRef.current);
+        fadeTimerRef.current = null;
+      }
 
       const token = ++generationIdRef.current;
       setSpinDone(false);
@@ -4755,18 +4822,22 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
       setSpinBoardVisible(false);
       setObsPhase("active");
 
-      const currentState = catStateRef.current;
-      if (currentState) {
-        if (obsPhase !== "active") {
-          await showStaticCatState(currentState);
-        }
-      } else if (params) {
+      if (params) {
         await primeOverlayFromCommand(params, slots);
       } else {
-        console.warn("[OBSSpinClient] Wheel command received but no cat state or params available");
-        resetWheelOverlay();
-        drawPlaceholder();
-        return;
+        const currentState = catStateRef.current;
+        if (currentState) {
+          if (obsPhase !== "active") {
+            await showStaticCatState(currentState);
+          }
+        } else {
+          console.warn(
+            "[OBSSpinClient] Wheel command received but no cat state or params available",
+          );
+          resetWheelOverlay();
+          drawPlaceholder();
+          return;
+        }
       }
 
       if (generationIdRef.current !== token) return;
@@ -4797,7 +4868,10 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
       setSpinVisible(false);
       fadeTimerRef.current = setTimeout(() => setObsPhase("idle"), 1500);
       return () => {
-        if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+        if (fadeTimerRef.current) {
+          clearTimeout(fadeTimerRef.current);
+          fadeTimerRef.current = null;
+        }
       };
     }
     setSpinVisible(false);
@@ -4806,28 +4880,81 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
   useEffect(() => {
     if (!session?.currentCommand) return;
     const cmd = session.currentCommand;
+    const cmdSeq = typeof cmd.seq === "number" ? cmd.seq : 0;
+    const isTransientCommand = cmd.type === "spin" || cmd.type === "wheel";
+    const isInitialCommand = !initializedSeqRef.current;
 
-    // On first load, just record the current seq — don't replay it
-    if (!initializedSeqRef.current) {
-      initializedSeqRef.current = true;
-      lastSeqRef.current = cmd.seq;
+    if (lastSeqRef.current !== null && cmdSeq <= lastSeqRef.current) return;
+
+    if (isTransientCommand && generationDisabled) {
       return;
     }
 
-    if (lastSeqRef.current !== null && cmd.seq <= lastSeqRef.current) return;
-    lastSeqRef.current = cmd.seq;
+    if (isInitialCommand) {
+      initializedSeqRef.current = true;
+      if (isTransientCommand && !resultAutoClearEnabledRef.current) {
+        lastSeqRef.current = cmdSeq;
+        resetCommandState();
+        if (!cmd.params) {
+          setObsPhase("idle");
+          drawPlaceholder();
+          return;
+        }
+        const restoredWheelSpin =
+          cmd.type === "wheel"
+            ? parseStreamWheelSpin((cmd as Record<string, unknown>).wheelSpin)
+            : null;
+        if (cmd.type === "wheel" && !restoredWheelSpin) {
+          setObsPhase("idle");
+          drawPlaceholder();
+          return;
+        }
+        const restoreToken = generationIdRef.current;
+        setObsPhase("active");
+        primeOverlayFromCommand(cmd.params, cmd.slots)
+          .then(() => {
+            if (generationIdRef.current !== restoreToken) return;
+            setSpinDone(true);
+            if (restoredWheelSpin) {
+              setWheelReward({ status: "settled", prize: restoredWheelSpin });
+              setWheelBannerVisible(true);
+            }
+          })
+          .catch((err) => {
+            if (generationIdRef.current !== restoreToken) return;
+            console.error("[OBSSpinClient] Failed to restore OBS command", err);
+            resetCommandState();
+            setObsPhase("idle");
+            drawPlaceholder();
+          });
+        return;
+      }
+
+      if (isTransientCommand) {
+        const commandAgeMs = Date.now() - cmd.timestamp;
+        const staleAfterMs = resultAutoClearSecondsRef.current * 1000 + 1500;
+        if (Number.isFinite(commandAgeMs) && commandAgeMs > staleAfterMs) {
+          lastSeqRef.current = cmdSeq;
+          resetCommandState();
+          setObsPhase("idle");
+          drawPlaceholder();
+          return;
+        }
+      }
+    }
+
+    lastSeqRef.current = cmdSeq;
 
     switch (cmd.type) {
       case "spin":
         if (!generationDisabled) {
+          resetCommandState();
+          const commandToken = generationIdRef.current;
           // Store the params from the control page so generateCatPlus uses them
           overrideParamsRef.current = {
             params: cmd.params,
             slots: cmd.slots,
           };
-          setParamRows([]);
-          setRollerLabel(null);
-          setRollerActiveValue(null);
           setRollerHighlight(false);
           setActiveParamId(null);
 
@@ -4843,8 +4970,10 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
 
             // Rich full-screen fireworks
             const fireConfetti = async () => {
+              if (generationIdRef.current !== commandToken) return;
               try {
                 const confetti = (await import("canvas-confetti")).default;
+                if (generationIdRef.current !== commandToken) return;
                 const colors = [
                   "#f59e0b",
                   "#ef4444",
@@ -4915,6 +5044,7 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
             const genRef = generatorRef.current;
             if (genRef?.generateRandomCat) {
               const cycle = async () => {
+                if (generationIdRef.current !== commandToken) return;
                 try {
                   const r = await genRef.generateRandomCat?.({
                     accessoryCount: computeLayerCount(accessoryRange),
@@ -4927,7 +5057,10 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
                         : undefined,
                     includeBaseColours,
                   });
-                  if (r?.canvas instanceof HTMLCanvasElement) {
+                  if (
+                    generationIdRef.current === commandToken &&
+                    r?.canvas instanceof HTMLCanvasElement
+                  ) {
                     setCountdownPreview(r.canvas.toDataURL("image/png"));
                   }
                 } catch {
@@ -4939,17 +5072,25 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
             }
 
             const tick = () => {
+              if (generationIdRef.current !== commandToken) return;
               remaining--;
               if (remaining <= 0) {
                 // "GO!" flash — big finale burst, hold 800ms then start spin
                 setCountdownValue(0);
-                if (previewIntervalRef.current)
+                if (previewIntervalRef.current) {
                   clearInterval(previewIntervalRef.current);
+                  previewIntervalRef.current = null;
+                }
                 // Massive finale — triple burst
                 fireConfetti();
-                setTimeout(() => fireConfetti(), 150);
-                setTimeout(() => fireConfetti(), 300);
+                setTimeout(() => {
+                  if (generationIdRef.current === commandToken) fireConfetti();
+                }, 150);
+                setTimeout(() => {
+                  if (generationIdRef.current === commandToken) fireConfetti();
+                }, 300);
                 countdownTimerRef.current = setTimeout(() => {
+                  if (generationIdRef.current !== commandToken) return;
                   setCountdownPreview(null);
                   setObsPhase("active");
                   generateCatPlus();
@@ -4959,8 +5100,14 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
                 fireConfetti();
                 // Last 3 seconds — extra bursts + start fading in the spin board
                 if (remaining <= 3) {
-                  setTimeout(() => fireConfetti(), 400);
-                  setTimeout(() => fireConfetti(), 700);
+                  setTimeout(() => {
+                    if (generationIdRef.current === commandToken)
+                      fireConfetti();
+                  }, 400);
+                  setTimeout(() => {
+                    if (generationIdRef.current === commandToken)
+                      fireConfetti();
+                  }, 700);
                   setSpinBoardVisible(true);
                 }
                 countdownTimerRef.current = setTimeout(tick, 1000);
@@ -5017,6 +5164,7 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
     generationDisabled,
     handleWheelCommand,
     generateCatPlus,
+    primeOverlayFromCommand,
     drawPlaceholder,
     resetCommandState,
     exactLayerCounts,

--- a/frontend/components/stream-control/OBSSpinClient.tsx
+++ b/frontend/components/stream-control/OBSSpinClient.tsx
@@ -1190,6 +1190,7 @@ function parseStreamWheelSpin(value: unknown): StreamWheelSpin | null {
   const randomBucket =
     typeof spin.randomBucket === "number" &&
     Number.isFinite(spin.randomBucket) &&
+    Number.isInteger(spin.randomBucket) &&
     spin.randomBucket >= 0 &&
     spin.randomBucket < 100
       ? spin.randomBucket
@@ -4887,6 +4888,10 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
     if (lastSeqRef.current !== null && cmdSeq <= lastSeqRef.current) return;
 
     if (isTransientCommand && generationDisabled) {
+      if (!initializing) {
+        lastSeqRef.current = cmdSeq;
+        initializedSeqRef.current = true;
+      }
       return;
     }
 
@@ -5162,6 +5167,7 @@ export function OBSSpinClient({ apiKey }: { apiKey: string }) {
   }, [
     session?.currentCommand,
     generationDisabled,
+    initializing,
     handleWheelCommand,
     generateCatPlus,
     primeOverlayFromCommand,

--- a/frontend/components/stream-control/StreamControlClient.tsx
+++ b/frontend/components/stream-control/StreamControlClient.tsx
@@ -35,10 +35,6 @@ import {
 } from "@/lib/portable-settings";
 import { cn } from "@/lib/utils";
 import {
-  pickClassicWheelPrize,
-  type StreamWheelSpin,
-} from "@/lib/wheel/classicWheel";
-import {
   AFTERLIFE_OPTIONS,
   computeLayerCount,
   withResolvedAfterlifeParams,
@@ -95,20 +91,6 @@ function canvasToPngBlob(canvas: CanvasExportSource): Promise<Blob> {
   });
 }
 
-function toWheelSpinPayload(
-  selection: ReturnType<typeof pickClassicWheelPrize>,
-  forced: boolean,
-): StreamWheelSpin {
-  return {
-    prizeName: selection.prize.name,
-    prizeIndex: selection.index,
-    color: selection.prize.color,
-    chance: selection.prize.chance,
-    randomBucket: selection.random,
-    forced,
-  };
-}
-
 /** Format a multiplier value like 1 -> "1x", 0.25 -> "0.25x", 2.50 -> "2.5x" */
 function formatMultiplier(v: number): string {
   return `${v.toFixed(2).replace(/\.?0+$/, "")}x`;
@@ -143,7 +125,6 @@ export function StreamControlClient() {
   const showBrbMut = useMutation(api.catStream.showBrb);
   const clearOverlayMut = useMutation(api.catStream.clearOverlay);
   const toggleTestModeMut = useMutation(api.catStream.toggleTestMode);
-  const logWheelSpinMut = useMutation(api.wheel.logSpin);
   const createMapper = useMutation(api.mapper.create);
   const updateMapperMeta = useMutation(api.mapper.updateMeta);
 
@@ -174,8 +155,10 @@ export function StreamControlClient() {
   const [catNameDraft, setCatNameDraft] = useState("");
   const [creatorNameDraft, setCreatorNameDraft] = useState("");
   const [metaDirty, setMetaDirty] = useState(false);
+  const [historySaving, setHistorySaving] = useState(false);
   const [metaSaving, setMetaSaving] = useState(false);
   const creatorFilledRef = useRef(false);
+  const spinRequestSeqRef = useRef(0);
   const lastResultRef = useRef<{
     canvas: HTMLCanvasElement | OffscreenCanvas;
     params: Record<string, unknown>;
@@ -416,7 +399,9 @@ export function StreamControlClient() {
   // Spin handler
   const handleSpin = useCallback(async () => {
     if (!generator || spinning || wheelSpinning || sceneCommandPending) return;
+    const requestSeq = ++spinRequestSeqRef.current;
     setSpinning(true);
+    setHistorySaving(false);
     try {
       if (!generator.generateRandomCat) {
         throw new Error("Generator does not support random cat generation");
@@ -460,32 +445,44 @@ export function StreamControlClient() {
         slots: result.slotSelections,
         countdownSeconds,
       });
+      setSpinning(false);
 
       // Store result only after the live stream command succeeds.
       lastResultRef.current = nextLastResult;
       setHasTint(generatedHasTint);
+      setCurrentProfileId(null);
+      setCurrentSlug(null);
+      setShareLink(null);
+      setMetaDirty(false);
+      toast.success("Spin triggered!");
 
-      // Persist to cat_profile (same as SingleCatPlus)
-      const catData = {
-        params: resolvedParams,
-        accessorySlots: result.slotSelections?.accessories ?? [],
-        scarSlots: result.slotSelections?.scars ?? [],
-        tortieSlots: result.slotSelections?.tortie ?? [],
-        counts: {
-          accessories: (result.slotSelections?.accessories ?? []).filter(
-            (s: string) => s !== "none",
-          ).length,
-          scars: (result.slotSelections?.scars ?? []).filter(
-            (s: string) => s !== "none",
-          ).length,
-          tortie: (result.slotSelections?.tortie ?? []).filter(Boolean).length,
-        },
-      };
-      const profile = await createMapper({
-        catData,
-        creatorName: creatorNameDraft.trim() || undefined,
-      });
-      if (profile) {
+      setHistorySaving(true);
+      try {
+        // Persist to cat_profile (same as SingleCatPlus)
+        const catData = {
+          params: resolvedParams,
+          accessorySlots: result.slotSelections?.accessories ?? [],
+          scarSlots: result.slotSelections?.scars ?? [],
+          tortieSlots: result.slotSelections?.tortie ?? [],
+          counts: {
+            accessories: (result.slotSelections?.accessories ?? []).filter(
+              (s: string) => s !== "none",
+            ).length,
+            scars: (result.slotSelections?.scars ?? []).filter(
+              (s: string) => s !== "none",
+            ).length,
+            tortie: (result.slotSelections?.tortie ?? []).filter(Boolean)
+              .length,
+          },
+        };
+        const profile = await createMapper({
+          catData,
+          creatorName: creatorNameDraft.trim() || undefined,
+        });
+        if (!profile) {
+          throw new Error("History save returned no profile");
+        }
+        if (spinRequestSeqRef.current !== requestSeq) return;
         setCurrentProfileId(profile.id);
         setCurrentSlug(profile.slug);
         const origin =
@@ -493,15 +490,26 @@ export function StreamControlClient() {
         setShareLink(`${origin}/view/${profile.slug}`);
         setCatNameDraft("");
         setMetaDirty(false);
+      } catch (err) {
+        if (spinRequestSeqRef.current !== requestSeq) return;
+        console.error("Failed to save stream history entry", err);
+        toast.warning("Spin triggered, but history save failed.");
+      } finally {
+        if (spinRequestSeqRef.current === requestSeq) {
+          setHistorySaving(false);
+        }
       }
-
-      toast.success("Spin triggered!");
     } catch (err) {
+      if (spinRequestSeqRef.current === requestSeq) {
+        setHistorySaving(false);
+      }
       toast.error(
         err instanceof Error ? err.message : "Failed to trigger spin",
       );
     } finally {
-      setSpinning(false);
+      if (spinRequestSeqRef.current === requestSeq) {
+        setSpinning(false);
+      }
     }
   }, [
     buildSessionSettings,
@@ -522,43 +530,19 @@ export function StreamControlClient() {
 
     const command = session?.currentCommand as
       | {
+          type?: string;
           params?: unknown;
-          slots?: unknown;
         }
       | undefined;
-    const params =
-      lastResultRef.current?.params ??
-      (command?.params as Record<string, unknown> | undefined);
-    const slots =
-      lastResultRef.current?.slots ??
-      (command?.slots as
-        | {
-            accessories?: string[];
-            scars?: string[];
-            tortie?: unknown[];
-          }
-        | undefined);
 
-    if (!params) {
+    if (command?.type !== "spin" || command.params === undefined) {
       toast.error("Spin a cat before spinning the wheel.");
       return;
     }
 
     setWheelSpinning(true);
     try {
-      const wheelSpin = toWheelSpinPayload(pickClassicWheelPrize(), false);
-      await triggerWheelMut({
-        params,
-        slots,
-        wheelSpin,
-      });
-      void logWheelSpinMut({
-        prizeName: wheelSpin.prizeName,
-        forced: wheelSpin.forced,
-        randomBucket: wheelSpin.randomBucket,
-      }).catch((error) => {
-        console.error("Failed to log manual stream wheel spin", error);
-      });
+      await triggerWheelMut({});
       toast.success("Wheel triggered!");
     } catch (err) {
       toast.error(
@@ -573,7 +557,6 @@ export function StreamControlClient() {
     sceneCommandPending,
     triggerWheelMut,
     wheelSpinning,
-    logWheelSpinMut,
   ]);
 
   // Save meta (cat name / creator name) to existing profile
@@ -775,11 +758,12 @@ export function StreamControlClient() {
   const fallbackCommand =
     (session?.currentCommand as
       | {
+          type?: string;
           params?: unknown;
         }
       | undefined) ?? undefined;
   const hasWheelSource = Boolean(
-    lastResultRef.current?.params ?? fallbackCommand?.params,
+    fallbackCommand?.type === "spin" && fallbackCommand.params !== undefined,
   );
   const commandBusy = spinning || wheelSpinning || sceneCommandPending !== null;
   const activeScene = getActiveStreamScene(session);
@@ -1478,9 +1462,16 @@ export function StreamControlClient() {
                 "hover:bg-foreground hover:text-background disabled:opacity-50",
               )}
               onClick={handleSaveMeta}
-              disabled={!currentProfileId || metaSaving || !metaDirty}
+              disabled={
+                !currentProfileId || historySaving || metaSaving || !metaDirty
+              }
             >
-              <Sparkles className="size-4" /> Save to History
+              {historySaving || metaSaving ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Sparkles className="size-4" />
+              )}{" "}
+              Save to History
             </button>
             <Link
               href="/history"

--- a/frontend/components/stream-control/StreamControlClient.tsx
+++ b/frontend/components/stream-control/StreamControlClient.tsx
@@ -41,6 +41,7 @@ import {
 import {
   AFTERLIFE_OPTIONS,
   computeLayerCount,
+  withResolvedAfterlifeParams,
 } from "@/utils/catSettingsHelpers";
 import {
   type AfterlifeOption,
@@ -432,13 +433,21 @@ export function StreamControlClient() {
         tortieCount: computeLayerCount(settings.tortieRange),
       });
 
+      const resolvedParams = withResolvedAfterlifeParams(
+        result.params as unknown as Record<string, unknown>,
+        settings.afterlifeMode,
+      );
+      const generatedHasTint = Boolean(
+        resolvedParams.darkForest || resolvedParams.dead,
+      );
+      const resolvedCanvas = (await generator.generateCat(resolvedParams))
+        .canvas;
+
       const nextLastResult = {
-        canvas: result.canvas,
-        params: result.params as unknown as Record<string, unknown>,
+        canvas: resolvedCanvas,
+        params: resolvedParams,
         slots: result.slotSelections,
       };
-      const p = result.params as unknown as Record<string, unknown>;
-      const generatedHasTint = Boolean(p.darkForest || p.darkMode || p.dead);
       // Flush settings (including creatorName) to Convex so OBS has them before spinning
       clearTimeout(syncTimer.current);
       const settingsWithCreator = buildSessionSettings(settings, {
@@ -447,7 +456,7 @@ export function StreamControlClient() {
       await saveSessionSettings(settingsWithCreator);
 
       await triggerSpinMut({
-        params: result.params,
+        params: resolvedParams,
         slots: result.slotSelections,
         countdownSeconds,
       });
@@ -458,7 +467,7 @@ export function StreamControlClient() {
 
       // Persist to cat_profile (same as SingleCatPlus)
       const catData = {
-        params: result.params,
+        params: resolvedParams,
         accessorySlots: result.slotSelections?.accessories ?? [],
         scarSlots: result.slotSelections?.scars ?? [],
         tortieSlots: result.slotSelections?.tortie ?? [],

--- a/frontend/convex/catStream.ts
+++ b/frontend/convex/catStream.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import type { MutationCtx } from "./_generated/server.js";
 import { mutation, query } from "./_generated/server.js";
-import { wheelSpinValidator } from "./schema.js";
+import { buildStreamWheelUpdate, pickStreamWheelSpin } from "./streamWheel.js";
 
 /** Helper: get the authenticated user or throw. */
 async function requireUser(ctx: MutationCtx) {
@@ -137,7 +137,6 @@ export const triggerSpin = mutation({
   args: {
     params: v.any(),
     slots: v.optional(v.any()),
-    wheelSpin: v.optional(wheelSpinValidator),
     countdownSeconds: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
@@ -151,7 +150,6 @@ export const triggerSpin = mutation({
       timestamp: Date.now(),
     };
     if (args.slots !== undefined) command.slots = args.slots;
-    if (args.wheelSpin !== undefined) command.wheelSpin = args.wheelSpin;
     if (args.countdownSeconds !== undefined)
       command.countdownSeconds = args.countdownSeconds;
 
@@ -167,27 +165,29 @@ export const triggerSpin = mutation({
  * Trigger only the wheel reward for the active cat on the OBS overlay.
  */
 export const triggerWheel = mutation({
-  args: {
-    params: v.any(),
-    slots: v.optional(v.any()),
-    wheelSpin: wheelSpinValidator,
-  },
-  handler: async (ctx, args) => {
+  args: {},
+  handler: async (ctx) => {
     const session = await requireSession(ctx);
-    const prevSeq = session.currentCommand?.seq ?? 0;
+    const sourceCommand = session.currentCommand;
+    if (
+      !sourceCommand ||
+      sourceCommand.type !== "spin" ||
+      sourceCommand.params === undefined
+    ) {
+      throw new Error("Spin a cat before spinning the wheel.");
+    }
+    if (session.lastWheelSpinForSeq === sourceCommand.seq) {
+      throw new Error("Wheel already spun for this cat.");
+    }
+    const now = Date.now();
+    const wheelSpin = pickStreamWheelSpin();
+    const wheelUpdate = buildStreamWheelUpdate(session, wheelSpin, now);
 
-    await ctx.db.patch(session._id, {
-      status: "active" as const,
-      currentCommand: {
-        type: "wheel",
-        seq: prevSeq + 1,
-        params: args.params,
-        slots: args.slots,
-        wheelSpin: args.wheelSpin,
-        timestamp: Date.now(),
-      },
-      updatedAt: Date.now(),
-    });
+    await ctx.db.insert("wheel_spins", wheelUpdate.wheelLog);
+
+    await ctx.db.patch(session._id, wheelUpdate.patch);
+
+    return wheelSpin;
   },
 });
 

--- a/frontend/convex/schema.ts
+++ b/frontend/convex/schema.ts
@@ -373,6 +373,7 @@ export default defineSchema({
       }),
     ),
     testMode: v.boolean(),
+    lastWheelSpinForSeq: v.optional(v.number()),
     createdAt: v.number(),
     updatedAt: v.number(),
   }).index("byUserId", ["userId"]),

--- a/frontend/convex/streamWheel.ts
+++ b/frontend/convex/streamWheel.ts
@@ -1,3 +1,6 @@
+// Keep this table in sync with ../lib/wheel/classicWheel.ts. Convex functions
+// should not import the client wheel module directly; streamWheel.test.ts
+// enforces alignment between the two definitions.
 export const STREAM_WHEEL_PRIZES = [
   { name: "Moondust", chance: 40, color: "#8b8b7a" },
   { name: "Starborn", chance: 25, color: "#6b8e4e" },

--- a/frontend/convex/streamWheel.ts
+++ b/frontend/convex/streamWheel.ts
@@ -1,0 +1,148 @@
+export const STREAM_WHEEL_PRIZES = [
+  { name: "Moondust", chance: 40, color: "#8b8b7a" },
+  { name: "Starborn", chance: 25, color: "#6b8e4e" },
+  { name: "Lunara", chance: 15, color: "#9b7c5d" },
+  { name: "Celestara", chance: 10, color: "#7a8ca5" },
+  { name: "Divinara", chance: 6, color: "#c97743" },
+  { name: "Holo Nova", chance: 3, color: "#f4e4c1" },
+  { name: "Singularity", chance: 1, color: "#d4af37" },
+] as const;
+
+const BUCKET_COUNT = 100;
+const UINT32_RANGE = 0x1_0000_0000;
+const REJECTION_LIMIT = Math.floor(UINT32_RANGE / BUCKET_COUNT) * BUCKET_COUNT;
+
+export type StreamWheelSpin = {
+  prizeName: string;
+  prizeIndex: number;
+  color: string;
+  chance: number;
+  randomBucket: number;
+  forced: boolean;
+};
+
+export type StreamWheelSourceCommand = {
+  type?: string;
+  seq?: number;
+  params?: unknown;
+  slots?: unknown;
+};
+
+export type StreamWheelSessionSnapshot = {
+  currentCommand?: StreamWheelSourceCommand | null;
+  lastWheelSpinForSeq?: number;
+};
+
+function secureRandomBucket() {
+  if (!globalThis.crypto?.getRandomValues) {
+    throw new Error("Secure random source unavailable");
+  }
+
+  const buffer = new Uint32Array(1);
+  let value = UINT32_RANGE;
+  while (value >= REJECTION_LIMIT) {
+    globalThis.crypto.getRandomValues(buffer);
+    value = buffer[0];
+  }
+  return value % BUCKET_COUNT;
+}
+
+function validateBucket(randomBucket: number) {
+  if (
+    !Number.isInteger(randomBucket) ||
+    randomBucket < 0 ||
+    randomBucket >= BUCKET_COUNT
+  ) {
+    throw new RangeError("Wheel random bucket must be an integer from 0 to 99.");
+  }
+  return randomBucket;
+}
+
+export function pickStreamWheelSpin(
+  randomBucket = secureRandomBucket(),
+): StreamWheelSpin {
+  const bucket = validateBucket(randomBucket);
+  let cumulative = 0;
+  for (
+    let prizeIndex = 0;
+    prizeIndex < STREAM_WHEEL_PRIZES.length;
+    prizeIndex++
+  ) {
+    const prize = STREAM_WHEEL_PRIZES[prizeIndex];
+    cumulative += prize.chance;
+    if (bucket < cumulative) {
+      return {
+        prizeName: prize.name,
+        prizeIndex,
+        color: prize.color,
+        chance: prize.chance,
+        randomBucket: bucket,
+        forced: false,
+      };
+    }
+  }
+
+  const prizeIndex = STREAM_WHEEL_PRIZES.length - 1;
+  const prize = STREAM_WHEEL_PRIZES[prizeIndex];
+  return {
+    prizeName: prize.name,
+    prizeIndex,
+    color: prize.color,
+    chance: prize.chance,
+    randomBucket: bucket,
+    forced: false,
+  };
+}
+
+export function buildStreamWheelUpdate(
+  session: StreamWheelSessionSnapshot,
+  wheelSpin: StreamWheelSpin,
+  now: number,
+) {
+  const sourceCommand = session.currentCommand;
+  if (
+    !sourceCommand ||
+    sourceCommand.type !== "spin" ||
+    sourceCommand.params === undefined ||
+    typeof sourceCommand.seq !== "number"
+  ) {
+    throw new Error("Spin a cat before spinning the wheel.");
+  }
+  if (session.lastWheelSpinForSeq === sourceCommand.seq) {
+    throw new Error("Wheel already spun for this cat.");
+  }
+
+  const currentCommand: {
+    type: "wheel";
+    seq: number;
+    params: unknown;
+    slots?: unknown;
+    wheelSpin: StreamWheelSpin;
+    timestamp: number;
+  } = {
+    type: "wheel",
+    seq: sourceCommand.seq + 1,
+    params: sourceCommand.params,
+    wheelSpin,
+    timestamp: now,
+  };
+  if (sourceCommand.slots !== undefined) {
+    currentCommand.slots = sourceCommand.slots;
+  }
+
+  return {
+    wheelSpin,
+    wheelLog: {
+      prizeName: wheelSpin.prizeName,
+      forced: wheelSpin.forced,
+      randomBucket: wheelSpin.randomBucket,
+      createdAt: now,
+    },
+    patch: {
+      status: "active" as const,
+      currentCommand,
+      lastWheelSpinForSeq: sourceCommand.seq,
+      updatedAt: now,
+    },
+  };
+}

--- a/frontend/lib/wheel/__tests__/streamWheel.test.ts
+++ b/frontend/lib/wheel/__tests__/streamWheel.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  STREAM_WHEEL_PRIZES,
+  buildStreamWheelUpdate,
+  pickStreamWheelSpin,
+} from "@/convex/streamWheel";
+import { CLASSIC_WHEEL_PRIZES } from "@/lib/wheel/classicWheel";
+
+describe("pickStreamWheelSpin", () => {
+  it("stays aligned with the OBS wheel prize table", () => {
+    expect(STREAM_WHEEL_PRIZES).toEqual(CLASSIC_WHEEL_PRIZES);
+  });
+
+  it("keeps prize odds positive and totaling 100 buckets", () => {
+    const totalChance = STREAM_WHEEL_PRIZES.reduce(
+      (sum, prize) => sum + prize.chance,
+      0,
+    );
+
+    expect(totalChance).toBe(100);
+    expect(STREAM_WHEEL_PRIZES.every((prize) => prize.chance > 0)).toBe(true);
+  });
+
+  it.each([
+    [0, 0],
+    [39, 0],
+    [40, 1],
+    [64, 1],
+    [65, 2],
+    [79, 2],
+    [80, 3],
+    [89, 3],
+    [90, 4],
+    [95, 4],
+    [96, 5],
+    [98, 5],
+    [99, 6],
+  ])("maps random bucket %s to prize index %s", (randomBucket, prizeIndex) => {
+    const spin = pickStreamWheelSpin(randomBucket);
+    const prize = STREAM_WHEEL_PRIZES[prizeIndex];
+
+    expect(spin).toMatchObject({
+      prizeName: prize.name,
+      prizeIndex,
+      color: prize.color,
+      chance: prize.chance,
+      randomBucket,
+      forced: false,
+    });
+  });
+
+  it.each([-1, 100, 0.5, Number.NaN])(
+    "rejects invalid bucket %s",
+    (randomBucket) => {
+      expect(() => pickStreamWheelSpin(randomBucket)).toThrow(RangeError);
+    },
+  );
+});
+
+describe("buildStreamWheelUpdate", () => {
+  it("requires a current spin command with params", () => {
+    const wheelSpin = pickStreamWheelSpin(99);
+
+    expect(() => buildStreamWheelUpdate({}, wheelSpin, 123)).toThrow(
+      "Spin a cat before spinning the wheel.",
+    );
+    expect(() =>
+      buildStreamWheelUpdate(
+        { currentCommand: { type: "lobby", seq: 7 } },
+        wheelSpin,
+        123,
+      ),
+    ).toThrow("Spin a cat before spinning the wheel.");
+    expect(() =>
+      buildStreamWheelUpdate(
+        { currentCommand: { type: "spin", seq: 7 } },
+        wheelSpin,
+        123,
+      ),
+    ).toThrow("Spin a cat before spinning the wheel.");
+  });
+
+  it("rejects a second wheel spin for the same cat", () => {
+    const wheelSpin = pickStreamWheelSpin(99);
+
+    expect(() =>
+      buildStreamWheelUpdate(
+        {
+          currentCommand: { type: "spin", seq: 7, params: { colour: "BLACK" } },
+          lastWheelSpinForSeq: 7,
+        },
+        wheelSpin,
+        123,
+      ),
+    ).toThrow("Wheel already spun for this cat.");
+  });
+
+  it("copies source params and slots into a wheel command and log row", () => {
+    const params = { colour: "BLACK", darkForest: true };
+    const slots = { accessories: ["flower"], scars: ["none"] };
+    const wheelSpin = pickStreamWheelSpin(99);
+    const update = buildStreamWheelUpdate(
+      {
+        currentCommand: { type: "spin", seq: 7, params, slots },
+      },
+      wheelSpin,
+      123,
+    );
+
+    expect(update.patch).toEqual({
+      status: "active",
+      currentCommand: {
+        type: "wheel",
+        seq: 8,
+        params,
+        slots,
+        wheelSpin,
+        timestamp: 123,
+      },
+      lastWheelSpinForSeq: 7,
+      updatedAt: 123,
+    });
+    expect(update.wheelLog).toEqual({
+      prizeName: wheelSpin.prizeName,
+      forced: false,
+      randomBucket: 99,
+      createdAt: 123,
+    });
+  });
+});

--- a/frontend/utils/catSettingsHelpers.test.ts
+++ b/frontend/utils/catSettingsHelpers.test.ts
@@ -47,17 +47,16 @@ describe("withResolvedAfterlifeParams", () => {
     });
   });
 
-  it("resolves random afterlife modes into one concrete params object", () => {
-    const random = vi
-      .spyOn(Math, "random")
-      .mockReturnValueOnce(0.05)
-      .mockReturnValueOnce(0.95);
+  it.each([
+    [0.05, { darkForest: true, darkMode: true, dead: false }],
+    [0.1, { darkForest: false, darkMode: false, dead: true }],
+    [0.15, { darkForest: false, darkMode: false, dead: true }],
+    [0.2, { darkForest: false, darkMode: false, dead: false }],
+    [0.25, { darkForest: false, darkMode: false, dead: false }],
+  ])("resolves both10 roll %s into one afterlife outcome", (roll, expected) => {
+    const random = vi.spyOn(Math, "random").mockReturnValueOnce(roll);
 
-    expect(withResolvedAfterlifeParams({}, "both10")).toMatchObject({
-      darkForest: true,
-      darkMode: true,
-      dead: false,
-    });
-    expect(random).toHaveBeenCalledTimes(2);
+    expect(withResolvedAfterlifeParams({}, "both10")).toMatchObject(expected);
+    expect(random).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/utils/catSettingsHelpers.test.ts
+++ b/frontend/utils/catSettingsHelpers.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withResolvedAfterlifeParams } from "./catSettingsHelpers";
+
+describe("withResolvedAfterlifeParams", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("turns afterlife off even when source params were tinted", () => {
+    const source = {
+      colour: "GINGER",
+      darkForest: true,
+      darkMode: true,
+      dead: true,
+    };
+
+    const params = withResolvedAfterlifeParams(source, "off");
+
+    expect(params).toMatchObject({
+      colour: "GINGER",
+      darkForest: false,
+      darkMode: false,
+      dead: false,
+    });
+    expect(source.darkForest).toBe(true);
+  });
+
+  it("forces Dark Forest and mirrors darkMode", () => {
+    expect(
+      withResolvedAfterlifeParams({ colour: "BLACK" }, "darkForce"),
+    ).toMatchObject({
+      colour: "BLACK",
+      darkForest: true,
+      darkMode: true,
+      dead: false,
+    });
+  });
+
+  it("forces StarClan without Dark Forest tint", () => {
+    expect(
+      withResolvedAfterlifeParams({ colour: "WHITE" }, "starForce"),
+    ).toMatchObject({
+      colour: "WHITE",
+      darkForest: false,
+      darkMode: false,
+      dead: true,
+    });
+  });
+
+  it("resolves random afterlife modes into one concrete params object", () => {
+    const random = vi
+      .spyOn(Math, "random")
+      .mockReturnValueOnce(0.05)
+      .mockReturnValueOnce(0.95);
+
+    expect(withResolvedAfterlifeParams({}, "both10")).toMatchObject({
+      darkForest: true,
+      darkMode: true,
+      dead: false,
+    });
+    expect(random).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/utils/catSettingsHelpers.ts
+++ b/frontend/utils/catSettingsHelpers.ts
@@ -37,11 +37,12 @@ export function resolveAfterlife(option: AfterlifeOption): {
       return { darkForest: Math.random() < 0.1, dead: false };
     case "star10":
       return { darkForest: false, dead: Math.random() < 0.1 };
-    case "both10":
-      return {
-        darkForest: Math.random() < 0.1,
-        dead: Math.random() < 0.1,
-      };
+    case "both10": {
+      const roll = Math.random();
+      if (roll < 0.1) return { darkForest: true, dead: false };
+      if (roll < 0.2) return { darkForest: false, dead: true };
+      return { darkForest: false, dead: false };
+    }
     case "darkForce":
       return { darkForest: true, dead: false };
     case "starForce":

--- a/frontend/utils/catSettingsHelpers.ts
+++ b/frontend/utils/catSettingsHelpers.ts
@@ -51,6 +51,20 @@ export function resolveAfterlife(option: AfterlifeOption): {
   }
 }
 
+/** Return cat params with a single resolved afterlife outcome applied. */
+export function withResolvedAfterlifeParams<T extends Record<string, unknown>>(
+  params: T,
+  option: AfterlifeOption,
+): T & { darkForest: boolean; darkMode: boolean; dead: boolean } {
+  const { darkForest, dead } = resolveAfterlife(option);
+  return {
+    ...params,
+    darkForest,
+    darkMode: darkForest,
+    dead,
+  };
+}
+
 /** Labeled afterlife options for dropdowns / selectors. */
 export const AFTERLIFE_OPTIONS: {
   label: string;


### PR DESCRIPTION
## Summary
- resolve afterlife flags once before sending OBS spin commands and history saves
- move stream wheel reward selection server-side and preserve cat params through wheel commands
- add focused tests for afterlife resolution and stream wheel reward handling

## Verification
- pnpm typecheck
- pnpm exec tsc -p convex/tsconfig.json --noEmit
- CG3_SKIP_RENDERER_BOOT=1 pnpm exec vitest run utils/catSettingsHelpers.test.ts lib/wheel/__tests__/streamWheel.test.ts
- pnpm exec biome lint components/stream-control/StreamControlClient.tsx components/stream-control/OBSSpinClient.tsx convex/catStream.ts convex/schema.ts convex/streamWheel.ts lib/wheel/__tests__/streamWheel.test.ts utils/catSettingsHelpers.ts utils/catSettingsHelpers.test.ts --max-diagnostics=50
- pnpm lint